### PR TITLE
Removes typo from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 ```
 "theme": "wild-cherry.sublime-theme",
-"color_scheme": "Packages//Wild Cherry/wild-cherry.tmTheme"
+"color_scheme": "Packages/Wild Cherry/wild-cherry.tmTheme"
 ```
 `color_scheme` defines how the code looks and `theme` defines how the sidebar, tabs, search, command palette work. 
 


### PR DESCRIPTION
There was a minor typo in color_scheme path