### PR TITLE
Fix PHP variable highlighting

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -85,6 +85,10 @@ atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-edi
 .variable {
 }
 
+.variable.php {
+  color: #F8F8F2;
+}
+
 .keyword {
   color: #e15d97;
 }


### PR DESCRIPTION
PHP variable highlighting inside double quotes was missing.

![test1](https://cloud.githubusercontent.com/assets/9437014/14456274/5da46048-00a4-11e6-8fba-03a1dad5fc34.png)

Now:

![test2](https://cloud.githubusercontent.com/assets/9437014/14456290/698e6b38-00a4-11e6-8221-50cc5f755c64.png)



